### PR TITLE
Update ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,7 +34,6 @@ jobs:
   deploy:
     runs-on: windows-latest
     needs: build
-    if: github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request includes a small but important change to the CI/CD workflow configuration in the `.github/workflows/ci-cd.yml` file. The change removes a condition that previously restricted the deploy job to only run on manual triggers.

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L37): Removed the condition `if: github.event_name == 'workflow_dispatch'` from the `deploy` job.